### PR TITLE
Précise les enjeux du langage inclusif

### DIFF
--- a/contribuer/recommandations.md
+++ b/contribuer/recommandations.md
@@ -43,9 +43,9 @@ Afin de faciliter l'intégration des nouvelles recrues et de fluidifier la commu
 
 ### Écriture épicène
 
-Nos outils s'adressent à toutes et à tous, mais la langue française impose souvent de faire des choix de genre \(féminin ou masculin\), avec une préférence pour le masculin « qui l'emporte » dans un groupe.
+Nos produits s'adressent à toutes et à tous, mais la langue française nous confronte souvent à des choix de genre \(féminin ou masculin\). Notamment, le genre "par défaut" est le masculin lorsqu'on évoque un groupe de personnes ("les usagers") ou une personne hypothétique ("le visiteur"), or des études empiriques montrent qu'indépendamment des descriptions théoriques de la grammaire de la langue, ces choix ont [un effet sur les représentations mentales](https://www.persee.fr/doc/psy_0003-5033_2008_num_108_2_30971) et donc sur la conception des produits.
 
-Pour éviter de genrer les outils et les rendre ainsi plus inclusifs, construisez des phrases **neutres en genre**.
+Pour éviter d'introduire des suppositions genrées et rendre ainsi plus inclusifs nos produits, construisez des phrases **neutres en genre**.
 
 Vous pouvez par exemple expliciter le sujet, en utilisant des termes génériques \([épicènes](https://fr.wikipedia.org/wiki/Épicène)\) tels que « personne ».
 


### PR DESCRIPTION
Suite à une conversation récente sur Slack, une micro-amélioration de la doc:
- évite d'accréditer, en la reprenant même avec la distance des guillemets, l'idée que le masculin "l'emporte"
- apporte des éléments empiriques sur l'impact du genre masculin "par défaut" quand on désigne des personnes abstraites (en groupe ou individuelle)
- améliore la formulation "genrer les produits" qui pêchait par excès de concision (on veut en fait dire, il me semble, "introduire des suppositions ou des stéréotypes de genre concernant les personnes amenées à utiliser nos produit")