### PR TITLE
Améliorer la définition du marrainage et clarifier l'existant de l'embarquement

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -16,6 +16,7 @@
   * [Environnement de travail](travailler-a-beta-gouv/bienvenue/environnement-de-travail.md)
   * [To do: que faire pendant les premiers mois à beta.gouv.fr ?](travailler-a-beta-gouv/bienvenue/to-do-darrivee.md)
   * [Marrainage](travailler-a-beta-gouv/bienvenue/marrainage.md)
+  * [Comment embarquer quelqu'un ?](travailler-a-beta-gouv/bienvenue/embarquement-par-le-recruteur.md)
 * [🎯 Recrutement](travailler-a-beta-gouv/recrutement/README.md)
   * [Comment recruter ?](travailler-a-beta-gouv/recrutement/comment-recruter.md)
   * [Publier une offre d'embauche](travailler-a-beta-gouv/recrutement/publier-une-offre-dembauche.md)

--- a/travailler-a-beta-gouv/bienvenue/embarquement-par-le-recruteur.md
+++ b/travailler-a-beta-gouv/bienvenue/embarquement-par-le-recruteur.md
@@ -3,7 +3,7 @@
 ## Checklist pour embarquer quelqu'un
 
 * [ ] Tu as envoyé un mail de bienvenue à la nouvelle recrue
-* [ ] Tu lui as demandé de lire la [page de bienvenue](./)
+* [ ] Tu lui as demandé de lire la [page de bienvenue](travailler-a-beta-gouv/bienvenue/README.md)
 * [ ] _\(Optionnel\) La nouvelle recrue a un compte Github sur lequelle il·elle a activé l'_[_authentification double facteur_](https://github.com/settings/security)
 * [ ] Créer pour la nouvelle recrue une fiche sur [https://beta.gouv.fr/communaute/](https://beta.gouv.fr/communaute/). \([Instructions pour créer une fiche sur beta.gouv.fr/communaute](https://github.com/betagouv/beta.gouv.fr/blob/master/CONTRIBUTING.md#ajouter-ou-modifier-un-membre-%C3%A0-la-communaut%C3%A9-betagouv)\)
 * [ ] Tu as créé une adresse email pour la nouvelle recrue \([Créer un compte email](../../outils/emails.md)\)

--- a/travailler-a-beta-gouv/bienvenue/embarquement-par-le-recruteur.md
+++ b/travailler-a-beta-gouv/bienvenue/embarquement-par-le-recruteur.md
@@ -5,23 +5,21 @@
 * [ ] Tu as envoyé un mail de bienvenue à la nouvelle recrue
 * [ ] Tu lui as demandé de lire la [page de bienvenue](./)
 * [ ] _\(Optionnel\) La nouvelle recrue a un compte Github sur lequelle il·elle a activé l'_[_authentification double facteur_](https://github.com/settings/security)
-* [ ] _\(Optionnel\) Tu as ajouté la nouvelle recrue à l'organisation_ [_betagouv_](https://github.com/orgs/betagouv/teams) _et à la team_ [_beta.gouv.fr_](https://github.com/orgs/betagouv/teams/beta-gouv-fr)
-* [ ] Pour la nouvelle recrue une fiche sur [https://beta.gouv.fr/communaute/](https://beta.gouv.fr/communaute/). \([Instructions pour créer une fiche sur beta.gouv.fr/communaute](https://github.com/betagouv/beta.gouv.fr/blob/master/CONTRIBUTING.md#ajouter-ou-modifier-un-membre-%C3%A0-la-communaut%C3%A9-betagouv)\)
+* [ ] Créer pour la nouvelle recrue une fiche sur [https://beta.gouv.fr/communaute/](https://beta.gouv.fr/communaute/). \([Instructions pour créer une fiche sur beta.gouv.fr/communaute](https://github.com/betagouv/beta.gouv.fr/blob/master/CONTRIBUTING.md#ajouter-ou-modifier-un-membre-%C3%A0-la-communaut%C3%A9-betagouv)\)
 * [ ] Tu as créé une adresse email pour la nouvelle recrue \([Créer un compte email](../../outils/emails.md)\)
 * [ ] La nouvelle recrue est sur le [Slack avec son adresse @beta.gouv.fr](https://startups-detat.slack.com/signup) et s'est présenté·e sur \#general
 * [ ] Tu as invité la nouvelle recrue à un standup
 * [ ] Si besoin tu as fait une demande de badge pour accéder à nos locaux \(La procédure pour Ségur est disponible sur le channel \#bureau-segur dans les fichiers partagés\)
-* [ ] Si il·elle est indépendant·e, elle sait à qui adresser ta facture et comment
+* [ ] Si il·elle est indépendant·e, elle sait à qui adresser sa facture et comment
 * [ ] Si il·elle est contractuel·le DINUM, il·elle s'est présenté·e au secrétariat de la DINUM
 
 ## FAQ
 
-Je ne maitrise pas GitHub, comment faire pour crééer la fiche de la nouvelle recrue ?
+Je ne maitrise pas GitHub, comment faire pour créer la fiche de la nouvelle recrue ?
 
-* Parcoure notre petit tutoriel pour t'aider dans tes premiers pas sur l'outil
-* Prend RdV pour l’onboarding avec un membre qui maîtrise \(à Ségur ou ailleurs\)
+* Parcours notre petit tutoriel pour t'aider dans tes premiers pas sur l'outil
+* Prends RdV pour l’onboarding avec un membre qui maîtrise \(à Ségur ou ailleurs\)
 
 La nouvelle recrue ne se servira jamais de GitHub, est-ce essentiel de créer un compte ?
 
-* Si tu est certain·e qu'il·elle n'en aura jamais besoin, tu peux créer sa fiche pour il·elle et passer à l'étape suivante.
-
+* Si tu est certain·e qu'il·elle n'en aura jamais besoin, tu peux créer sa fiche pour à sa place et passer à l'étape suivante.

--- a/travailler-a-beta-gouv/bienvenue/embarquement-par-le-recruteur.md
+++ b/travailler-a-beta-gouv/bienvenue/embarquement-par-le-recruteur.md
@@ -1,0 +1,27 @@
+# Comment embarquer quelqu'un ?
+
+## Checklist pour embarquer quelqu'un
+
+* [ ] Tu as envoyé un mail de bienvenue à la nouvelle recrue
+* [ ] Tu lui as demandé de lire la [page de bienvenue](./)
+* [ ] _\(Optionnel\) La nouvelle recrue a un compte Github sur lequelle il·elle a activé l'_[_authentification double facteur_](https://github.com/settings/security)
+* [ ] _\(Optionnel\) Tu as ajouté la nouvelle recrue à l'organisation_ [_betagouv_](https://github.com/orgs/betagouv/teams) _et à la team_ [_beta.gouv.fr_](https://github.com/orgs/betagouv/teams/beta-gouv-fr)
+* [ ] Pour la nouvelle recrue une fiche sur [https://beta.gouv.fr/communaute/](https://beta.gouv.fr/communaute/). \([Instructions pour créer une fiche sur beta.gouv.fr/communaute](https://github.com/betagouv/beta.gouv.fr/blob/master/CONTRIBUTING.md#ajouter-ou-modifier-un-membre-%C3%A0-la-communaut%C3%A9-betagouv)\)
+* [ ] Tu as créé une adresse email pour la nouvelle recrue \([Créer un compte email](../../outils/emails.md)\)
+* [ ] La nouvelle recrue est sur le [Slack avec son adresse @beta.gouv.fr](https://startups-detat.slack.com/signup) et s'est présenté·e sur \#general
+* [ ] Tu as invité la nouvelle recrue à un standup
+* [ ] Si besoin tu as fait une demande de badge pour accéder à nos locaux \(La procédure pour Ségur est disponible sur le channel \#bureau-segur dans les fichiers partagés\)
+* [ ] Si il·elle est indépendant·e, elle sait à qui adresser ta facture et comment
+* [ ] Si il·elle est contractuel·le DINUM, il·elle s'est présenté·e au secrétariat de la DINUM
+
+## FAQ
+
+Je ne maitrise pas GitHub, comment faire pour crééer la fiche de la nouvelle recrue ?
+
+* Parcoure notre petit tutoriel pour t'aider dans tes premiers pas sur l'outil
+* Prend RdV pour l’onboarding avec un membre qui maîtrise \(à Ségur ou ailleurs\)
+
+La nouvelle recrue ne se servira jamais de GitHub, est-ce essentiel de créer un compte ?
+
+* Si tu est certain·e qu'il·elle n'en aura jamais besoin, tu peux créer sa fiche pour il·elle et passer à l'étape suivante.
+

--- a/travailler-a-beta-gouv/bienvenue/marrainage.md
+++ b/travailler-a-beta-gouv/bienvenue/marrainage.md
@@ -4,46 +4,27 @@ Toute personne membre de l'Incubateur depuis plus de six mois peut marrainer un 
 
 ### Je suis recruteur
 
-Si tu recrutes quelqu'un, tu dois lui trouver un marrain. Pour cela demande sur [🔒`#incubateur-onboarding`](https://startups-detat.slack.com/messages/incubateur-onboarding/).
+Si tu recrutes quelqu'un, tu dois lui trouver un marrain. Pour en trouver un, vas sur le secretariat \( [https://secretariat.beta.gouv.fr](https://secretariat.beta.gouv.fr) \), recherche la fiche de la personne et clique sur "Cherche un·e marrain·e".
 
-Il doit s'agir d'une personne qui a plus de 6 mois d'ancienneté, qui a de la bande passante pour répondre aux questions du nouvel arrivant, qui n'est pas dans la même équipe. Si plusieurs personnes sont dispo, privilégie celle qui marraine le moins.
-
-### Je suis marrain
+### Je suis marrain·e
 
 En tant que marrain, tu t'engages à :
 
-* Présenter au nouvel arrivant les autres équipes et leurs produits.
+* Présenter au nouvel arrivant d'autres équipes et produits.
 
-> N'hésite pas à utiliser le mur des Startups d’État et/ou à faire le tour des équipes sur place pour mettre un visage sur les équipes.
+> N'hésite pas à faire le tour des équipes sur place pour mettre un visage sur les équipes. Vous pouvez faire le tour de slack
 
 * Présenter l'Incubateur, son histoire et son mode de fonctionnement.
 
-> En attendant la sortie d'un ouvrage collectif officiel 📖, raconte ton histoire et assure-toi que le nouvel arrivant participe au prochain \[\[séminaire\]\] !
+> En attendant la sortie d'un ouvrage collectif officiel 📖, raconte ton histoire et assure-toi que le nouvel arrivant participe au prochain séminaire !   
+> Si tu ne connais pas l'histoire c'est le moment de l'apprendre avec ton Padawan !
 
 * Rester dispo pour répondre à toutes les questions du jeune Padawan.
 * Faire un follow-up un mois après son arrivée.
 
-## Checklist du Marrain :
+**Si ce n'est pas déjà fait, tu peux gérer l'embarquement de ton·ta filleul·e en suivant ce lien :**
 
-* [ ] Tu as envoyé un mail de bienvenue et reservé une demi journée pour onboarder la nouvelle recrue
-* [ ] Tu as demandé à ton·ta filleul·e de lire la [page de bienvenue](./)
-* [ ] _\(Optionnel\) Ton·ta filleul·e a un compte Github sur lequelle il·elle a activé l'_[_authentification double facteur_](https://github.com/settings/security)
-* [ ] _\(Optionnel\) Tu as ajouté ton·ta filleul·e à l'organisation_ [_betagouv_](https://github.com/orgs/betagouv/teams) _et à la team_ [_beta.gouv.fr_](https://github.com/orgs/betagouv/teams/beta-gouv-fr)
-* [ ] Ton·ta filleul·e a une fiche sur [https://beta.gouv.fr/communaute/](https://beta.gouv.fr/communaute/). \([Instructions pour créer une fiche sur beta.gouv.fr/communaute](https://github.com/betagouv/beta.gouv.fr/blob/master/CONTRIBUTING.md#ajouter-ou-modifier-un-membre-%C3%A0-la-communaut%C3%A9-betagouv)\)
-* [ ] Tu as créé une adresse email pour ton·ta filleul·e \([Créer un compte email](../../outils/emails.md)\)
-* [ ] Ton·ta filleul·e est sur le [Slack avec son adresse @beta.gouv.fr](https://startups-detat.slack.com/signup) et s'est présenté·e sur \#general
-* [ ] Tu as invité ton·ta filleul·e à un standup
-* [ ] Si besoin tu as fait une demande de badge pour accéder à nos locaux \(La procédure pour Ségur est disponible sur le channel \#bureau-segur dans les fichiers partagés\)
-* [ ] Si il·elle est indépendant·e, elle sait à qui adresser ta facture et comment
-* [ ] Si il·elle est contractuel·le DINSIC, il·elle s'est présenté·e au secrétariat de la DINSIC
+{% page-ref page="embarquement-par-le-recruteur.md" %}
 
-## FAQ
 
-Je ne maitrise pas GitHub, comment faire pour crééer la fiche de mon·ma filleul·e ?
 
-* Parcoure notre petit tutoriel pour t'aider dans tes premiers pas sur l'outil
-* Prend RdV pour l’onboarding avec un membre qui maîtrise \(à Ségur ou ailleurs\)
-
-Mon·Ma filleul·e ne se servira jamais de GitHub, est-ce essentiel de créer un compte ?
-
-* Si tu est certain·e qu'il·elle n'en aura jamais besoin, tu peux créer sa fiche pour il·elle et passer à l'étape suivante.

--- a/travailler-a-beta-gouv/bienvenue/marrainage.md
+++ b/travailler-a-beta-gouv/bienvenue/marrainage.md
@@ -4,15 +4,15 @@ Toute personne membre de l'Incubateur depuis plus de six mois peut marrainer un 
 
 ### Je suis recruteur
 
-Si tu recrutes quelqu'un, tu dois lui trouver un marrain. Pour en trouver un, vas sur le secretariat \( [https://secretariat.beta.gouv.fr](https://secretariat.beta.gouv.fr) \), recherche la fiche de la personne et clique sur "Cherche un·e marrain·e".
+Si tu recrutes quelqu'un, tu dois lui trouver un marrain. Pour en trouver un, vs sur le site du secretariat \( [https://secretariat.beta.gouv.fr](https://secretariat.beta.gouv.fr) \), recherche la fiche de la personne et clique sur "Cherche un·e marrain·e".
 
 ### Je suis marrain·e
 
 En tant que marrain, tu t'engages à :
 
-* Présenter au nouvel arrivant d'autres équipes et produits.
+* Présenter à la nouvelle recrue d'autres équipes et produits.
 
-> N'hésite pas à faire le tour des équipes sur place pour mettre un visage sur les équipes. Vous pouvez faire le tour de slack
+> N'hésite pas à faire le tour des équipes sur place pour faire connaissance en chair et en os. Vous pouvez faire le tour de Slack
 
 * Présenter l'Incubateur, son histoire et son mode de fonctionnement.
 
@@ -25,6 +25,5 @@ En tant que marrain, tu t'engages à :
 **Si ce n'est pas déjà fait, tu peux gérer l'embarquement de ton·ta filleul·e en suivant ce lien :**
 
 {% page-ref page="embarquement-par-le-recruteur.md" %}
-
 
 


### PR DESCRIPTION
## Marrainage

Nous avions défini ensemble, il y a 2 ou 3 ans un rôle de marrain.e.

## Constats
- Il y a peu de marrain.e qui sont désigné pour les nouveaux venus
- C'est en général un membre de l'équipe ou le recruteur (coach ou co-animataur) qui s'occupe de toutes les taches
- Très peu de marrain.e se sont occupé de l'embarquement réel d'un marrainé
- Nous avons implémenté très récemment dans l'application Secretariat un tirage au sort de marrain.e
    - Dans ce cas, une partie de l'embarquement a été faite (compte Github, fiche sur beta.gouv.fr et l'adresse email)
    - Il faut 8 jours en moyenne et l'application demande à au moins 6 personnes (cela peut aller jusqu'à 9 personnes et 20 jours pour trouver une marrain). 

## Proposition
Déplacer la checklist d'embarquement que l'on avait attribué au marrain.e (Github, création de compte) et la mettre pour l'embarquement en général
- Alléger le travail du marrain.e:
    - Présenter au nouvel arrivant les autres équipes et leurs produits.
    - Présenter l’Incubateur, son histoire et son mode de fonctionnement.
    - Rester dispo pour répondre à toutes les questions du jeune Padawan.
    - Faire un follow-up un mois après son arrivée.
PS : le marrain pourrait s'occuper de l'embarquement mais ce n'est pas obligatoire