### PR TITLE
Correction du port POP3

### DIFF
--- a/outils/emails.md
+++ b/outils/emails.md
@@ -47,7 +47,7 @@ Pour les autres logiciels, la configuration se fait de manière suivante :
 | Paramètre | Valeur |
 | :--- | :--- |
 | Serveur | ssl0.ovh.net |
-| Port | 993 |
+| Port | 995 |
 | Méthode de chiffrement | SSL  |
 | Nom d'utilisateur | ton adresse beta.gouv.fr |
 | Mot de passe | le mot de passe de ton email |


### PR DESCRIPTION
Comme le mentionne la doc OVH le port de réception est 995 et non pas 993 (testé aujourd'hui même)

https://docs.ovh.com/fr/emails/mail-mutualise-guide-configuration-dun-e-mail-mutualise-ovh-sur-linterface-de-gmail/