### PR TITLE
fix(mail): changement des ports pour l'adresse mail sur OVH

### DIFF
--- a/outils/emails.md
+++ b/outils/emails.md
@@ -57,7 +57,7 @@ Pour les autres logiciels, la configuration se fait de manière suivante :
 | Paramètre | Valeur |
 | :--- | :--- |
 | Serveur | ssl0.ovh.net |
-| Port | 995 |
+| Port | 993 |
 | Méthode de chiffrement | SSL  |
 | Nom d'utilisateur | ton adresse beta.gouv.fr |
 | Mot de passe | le mot de passe de ton email |
@@ -67,7 +67,7 @@ Pour les autres logiciels, la configuration se fait de manière suivante :
 | Paramètre | Valeur |
 | :--- | :--- |
 | Serveur | ssl0.ovh.net |
-| Port | 587 |
+| Port | 465 |
 | Méthode de chiffrement | TLS |
 | Nom d'utilisateur | ton adresse beta.gouv.fr |
 | Mot de passe | le mot de passe de ton email |


### PR DESCRIPTION
Bonjour à vous,

Je viens par ce commit faire une petite update sur la documentation pour se connecter à l'email via une messagerie externe.

Source : https://help.ovhcloud.com/csm/fr-mx-plan-outlook-windows-configuration?id=kb_article_view&sysparm_article=KB0052099

Bonne journée

