### PR TITLE
Message plus clair pour l'email d'accès à Mattermost

### DIFF
--- a/gerer-sa-startup-detat-ou-de-territoires-au-quotidien/decouvrir-les-differents-metiers-dune-startup-detat/embarquement-par-le-recruteur.md
+++ b/gerer-sa-startup-detat-ou-de-territoires-au-quotidien/decouvrir-les-differents-metiers-dune-startup-detat/embarquement-par-le-recruteur.md
@@ -11,7 +11,7 @@
 <!---->
 
 * celui pour définir son accès à son email (à recevoir sur l'email renseigné dans l'onboarding)
-* &#x20;et celui pour son accès à [Mattermost](https://mattermost.incubateur.net) (à recevoir sur l'email renseigné sur son adresse @beta.gouv.fr)
+* &#x20;et celui pour son accès à [Mattermost](https://mattermost.incubateur.net) (à recevoir sur son adresse @beta.gouv.fr)
 
 <!---->
 


### PR DESCRIPTION
Actuellement, sur la page "Comment embarquer quelqu'un", on nous dit que la personne va recevoir deux emails, un pour accéder à son email Beta, et l'autre pour l'accès à Mattermost, cf capture ci-dessous :

![Screenshot 2024-04-23 at 11-18-19 Comment embarquer quelqu'un Le guide de la communauté beta gouv](https://github.com/betagouv/doc.incubateur.net-communaute/assets/1522772/f36f3b94-ebce-4098-a134-e30a167f4cc2)


Pour le deuxième email, il est précisé "à recevoir sur l'email renseigné sur son adresse @beta.gouv.fr", il me semble qu'il y a une erreur de copier / coller, et qu'il faudrait plutôt avoir "à recevoir sur son adresse @beta.gouv.fr"