### PR TITLE
Suppression référence à Ruby(Rails) dans les choix de technologies

### DIFF
--- a/gerer-son-produit/les-standards/standards-de-qualite-beta.gouv.fr/choisir-des-technologies.md
+++ b/gerer-son-produit/les-standards/standards-de-qualite-beta.gouv.fr/choisir-des-technologies.md
@@ -9,8 +9,6 @@ Chez Beta Gouv, les équipes sont libres de choisir les technologies de leurs ch
 * JavaScript/TypeScript (NodeJS)
 * Python ([Django](https://www.djangoproject.com))
 
-Ruby ([Rails](https://rubyonrails.org/)) est aussi utilisé quand cela fonctionne avec le cadre technique de l'administration porteuse. Ce choix doit donc être fait en connaissance de cause.
-
 > Certains incubateurs du réseau beta.gouv.fr ont mis en place des standards propres, consultez [votre référent(e) tech](../../gestion-au-quotidien/tech/to-do-liens-avec-les-referents-techs.md).
 
 {% hint style="info" %}


### PR DESCRIPTION
Proposition de supprimer la référence à Ruby (Rails) dans le choix des technologies / stack beta

Motivations :
- langage et framework en perte de vitesse et d'adoption
- grosses difficultés de recrutement sur ces techno