### PR TITLE
Mise à jour du lien pour demande accès Sentry

### DIFF
--- a/les-outils-de-la-communaute/autres/sentry.md
+++ b/les-outils-de-la-communaute/autres/sentry.md
@@ -12,7 +12,7 @@ Sentry permet de réagir rapidement en cas d'incident, d'analyser un incident pa
 
 L'équipe animation met à disposition une instance sur [https://sentry.incubateur.net](https://sentry.incubateur.net)
 
-Vous pouvez faire une demande d'accès via un [ticket OPS sur le channel mattermost](https://mattermost.incubateur.net/betagouv/channels/incubateur-demandes-ops).
+Vous pouvez [demander un accès via l'espace membre](https://espace-membre.incubateur.net/services/sentry).
 
 ### Recommandations
 


### PR DESCRIPTION
L'accès à l'outil Sentry passe désormais par l'espace membre.

Vu à la base en essayant de [demander un accès auprès des ops](https://airtable.com/appmmy7DR3T8jqsTx/pagPeUwMDA7PskrDQ/form) : 
![capture d'écran du formulaire Airtable pour une demande auprès des ops de beta](https://github.com/user-attachments/assets/ac56cb2a-5c53-4622-98c2-e50c9769bbb9)
