### PR TITLE
budget : mise à jour de la publication du budget

### DIFF
--- a/gerer-son-produit/standards/transparence/publier-son-budget.md
+++ b/gerer-son-produit/standards/transparence/publier-son-budget.md
@@ -7,42 +7,54 @@ hidden: true
 
 # Publier son budget
 
-Dans son dernier [rapport sur le pilotage de la transformation numérique de l’État](https://www.ccomptes.fr/fr/publications/le-pilotage-de-la-transformation-numerique-de-letat-par-la-direction) par la Direction interministérielle du numérique, la Cour des comptes a réaffirmé la nécessité de publier le budget, et les objectifs d'impact de chaque équipe.
+[Publier son budget fait partie de nos standards](https://github.com/betagouv/standards/blob/main/transparence/le-produit-communique-sur-son-budget.md). Pour vous aider dans cette tâche, l'équipe de beta.gouv.fr vous propose la méthologie suivante ainsi qu'un Grist (c.f fin de page) pour publier votre budget.
 
-<figure><img src="../../../.gitbook/assets/Capture d’écran 2024-07-19 à 19.35.02.png" alt=""><figcaption><p>Rapport S-2024-0754 de la Cour des comptes</p></figcaption></figure>
+## Le référentiel de saisie
 
-### Que publier ?
+La saisie de votre budget repose sur plusieurs informations clés :
 
-{% hint style="info" %}
-Chaque Startup d'État est libre de publier ce qu'elle souhaite, sous le format qu'elle souhaite, et au niveau de détail qu'elle souhaite.
-{% endhint %}
+* l'année où est effectué la dépense, avec le montant en autorisation d'engagement (AE) et en crédit de paiement (CP)
+* la catégorisation de la dépense : **quelle activité et quelle ressource concerne cette dépense** ?
 
-Publier l'enveloppe globale du budget de la Startup d'État est déjà un énorme pas en avant. En effet, très peu de Startups d'État partagent leur budget aujourd'hui.
+Ci-dessous le détail la définition de chaque activité et chaque ressource possible. Ce référentiel a vocation à être commun à l'ensemble des produits numériques, y compris ceux ne travaillant pas en mode produit agile à impact afin de pouvoir efficacement comparer les coûts et sécuriser les budgets.
 
-**Il vaut mieux publier un chiffre avec quelques zones d'incertitudes et sans détail que rien.** Le budget que vous publiez n'a pas besoin d'être parfait ni exhaustif.
+### Activités
 
-### Page dédiée
+Les activités concernent la nature où le métier associé à cette dépense : est-ce une dépense qui servira à déployer le service auprès de plus d'utilisateur ? à le développer ? à le sécuriser ?
 
-Un modèle de page budget que vous pouvez adapter est disponible ici :
+| Activité | Description |
+|---------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **Data** | Collecte, le stockage, l’analyse et la gestion des données.  |
+| **Hébergement non cloud** | Infrastructure et maintenance pour des serveurs hébergés en interne ou en externe.  |
+| **Hébergement cloud** | Utilisation de services cloud (Scalingo, CleverCloud, …) pour héberger les applications et les données.  |
+| **Ops** | Automatisation (IaC), administration et maintenance des infrastructures et des middlewares, suivi et exploitation des applications, mise en production avec validation de conformité. |
+| **Réseau** | Équipements et services réseau (routeurs, VPN, bande passante, etc.).  |
+| **Gestion administrative** | Gestion financière et de ressources humaines.  |
+| **Sécurité** | Cybersécurité, protection des données, audits et conformité, homologations.  |
+| **Déploiement / Communication / Relations institutionnelles** | Acquisition de nouveaux utilisateurs, gestion de partenariats, retours utilisateurs, marketing.  |
+| **Support** | Qualification, routage des incidents, résolution avancée, accompagnement des utilisateurs et correction des anomalies.  |
+| **Développeur** | Écriture de lignes de code par des agents ou prestataires, récupération de code par achat de logiciel, licences et recours à des services en SaaS.  |
+| **Manageur / MOA / Coaching / PO/PM / Pilotage** | Intrapreneur, gestion de projet, spécifications fonctionnelles et coordination entre équipes, audit qualité et méthode, pilotage transverse.  |
+| **Designer** | Design du service numérique.  |
+| **Autre** | |
 
-{% embed url="https://betagouv.github.io/template-nextjs/budget" %}
+### Ressources
 
-Vous pouvez consulter d'autres exemples sur le [récapitulatif DashLord des budgets](http://dashlord.incubateur.net/summary/budget/)
+Les ressources concernent le type de ressource mobilisé pour effectuer cette dépense : s'agit-il de payer un prestataire externe ? un agent public ? un logiciel ?
 
-### Rajouter le lien vers le budget sur la fiche de la Startup d'État sur beta.gouv.fr
+| Ressource | Description |
+|--------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **Personnel** | Toutes les dépenses humaines internalisées, incluant rémunérations d’activité, cotisations et contributions sociales, prestations sociales, allocations sociales diverses, salaires et charges employeurs. Utilisez le superbrut basé sur le simulateur [mon-entreprise.](https://mon-entreprise.urssaf.fr/simulateurs/salaire-brut-net). En l'absence d'information sur le salaire, vous pouvez vous [référer à la grille DINUM.](https://www.numerique.gouv.fr/uploads/Circulaire%20n%C2%B06434-SG%20du%203%20janvier%202024%20-%20r%C3%A9f%C3%A9rentiel%20num%C3%A9rique.pdf) |
+| **Prestations externes** | Toutes les dépenses humaines externalisées, y compris prestations intellectuelles, emploi de freelances, forfaits, achats de services, assistance technique et honoraires de conseil.  |
+| **Matériel** | Achats, maintenance, locations et achats de petits matériels.  |
+| **Logiciel / SaaS / PaaS** | Achats de logiciels, locations, redevances et licences.  |
+| **Frais de structure (locaux, assurances, impôts et taxes)** | Dépenses liées aux locaux, assurances, impôts et taxes.  |
+| **Autre** | |
 
-Dans [l'espace-membre](https://espace-membre.incubateur.net), accédez à la fiche de votre produit puis "Modifier les informations" puis indiquez l'URL de votre page budget dans le champ "URL du budget".
+## La saisie et la publication du budget
 
-Cette information apparaitra ensuite sur votre fiche produit beta.gouv :
+La saisie s'effectue sur un [Grist](https://grist.numerique.gouv.fr/o/docs/fTjFnK7Bhvuo/Depenses-numeriques/p/1) dédié via la vue "Renseignez votre budget"
 
-<div align="left">
+Vous pouvez ensuite reporter les informations saisies dans Grist sur le site public de votre produit numérique si vous en avez un.
 
-<figure><img src="../../../.gitbook/assets/Capture d’écran 2024-07-19 à 17.20.46.png" alt="" width="255"><figcaption></figcaption></figure>
-
-</div>
-
-### Page commune de publication des budgets
-
-Si vous ne pouvez pas publier votre propre page, une page publique regroupant les budgets de plusieurs Startup d'État existe sur [https://pad.numerique.gouv.fr/rHMnemklQm6Sww5yVCI9ow?view#](https://pad.numerique.gouv.fr/rHMnemklQm6Sww5yVCI9ow?view)
-
-Toutes les Startup d'État sont invitées à modifier cette page pour y rajouter leur budget.
+Enfin, rajoutez le lien vers le budget sur la fiche de votre startup dans l'espace membre. Accédez à la fiche de votre produit puis "Modifier les informations" puis indiquez l'URL de la page de votre site public dans le champ "URL du budget". Cette information apparaitra ensuite sur votre fiche produit beta.gouv. Si votre produit ne dispose pas d'un site public, vous pouvez simplement partager l'URL du [Grist](https://grist.numerique.gouv.fr/o/docs/fTjFnK7Bhvuo/Depenses-numeriques/p/1) où votre budget a été saisi.


### PR DESCRIPTION
L'équipe de l'ISN et de la DINUM a fait évoluer sa saisie de budget en recommandant un Grist[1] qui permettra d'accéder à une donnnée de meilleure qualité, structurée et homogène.

Les ressources précédentes (le document sur pad.numerique.gouv.fr) sont décommissionnées mais pas supprimées pour conserver/transposer cette information.

Le page budget du template NextJS est obsolète.

[1]: https://github.com/betagouv/standards/pull/91