### PR TITLE
Mise à jour des liens vers l'agenda public LaSuite

### DIFF
--- a/contribuer-a-la-communaute/README.md
+++ b/contribuer-a-la-communaute/README.md
@@ -6,7 +6,7 @@ Il est temps de te mettre à jour sur les événements qui se dérouleront proch
 Mais avant tout, as-tu rejoint notre agenda public ? \
 En rejoignant notre agenda, tu auras accès à toutes les informations concernant ces événements, ainsi que des rappels utiles pour ne manquer aucune occasion de partager avec les autres membres des incubateurs. 📅
 
-[**👉 Rejoignez notre agenda public ici !**](https://calendar.google.com/calendar/u/0/embed?src=0ieonqap1r5jeal5ugeuhoovlg@group.calendar.google.com\&ctz=Europe/Paris)
+[**👉 Rejoignez notre agenda public ici !**](http://messagerie.numerique.gouv.fr/appsuite/api/share/0366722a002da2b9366722802da84e5eb694970c9c989a65/1/2/Y2FsOi8vMC8yMjczNA)
 
 
 

--- a/decouvrir-beta.gouv.fr/la-communaute/les-rituels/clubs-de-partage-dexperience.md
+++ b/decouvrir-beta.gouv.fr/la-communaute/les-rituels/clubs-de-partage-dexperience.md
@@ -8,7 +8,7 @@ description: >-
 
 Ils se déroulent en présentiel pour les participants au forum et en distanciel pour les personnes n'ayant pas pu se déplacer.
 
-Ils ont habituellement lieu de 16h à 17h (voir [l'agenda public](https://calendar.google.com/calendar/u/0/embed?src=0ieonqap1r5jeal5ugeuhoovlg@group.calendar.google.com\&ctz=Europe/Paris)).
+Ils ont habituellement lieu de 16h à 17h (voir [l'agenda public](http://messagerie.numerique.gouv.fr/appsuite/api/share/0366722a002da2b9366722802da84e5eb694970c9c989a65/1/2/Y2FsOi8vMC8yMjczNA)).
 
 **Le format** : 1h d'atelier sous [format codev](https://www.google.com/url?q=https://bloculus.com/fast-codev-30-min-pour-resoudre-probleme/\&sa=D\&source=calendar\&usd=2\&usg=AOvVaw1h2JUyLyJLX66AQar5iZ0e) sur des sujets qui vous intéressent vous et qui sont liés soit au lien entre structures du réseau, soit à des défis auxquels vous vous confrontez et sur lesquels vous souhaiteriez avoir de l'aide collective.
 

--- a/decouvrir-beta.gouv.fr/la-communaute/les-rituels/seminaire.md
+++ b/decouvrir-beta.gouv.fr/la-communaute/les-rituels/seminaire.md
@@ -16,7 +16,7 @@ Il s’agit d’une journée de rencontres et d’échanges en présentiel pour 
 
 ## Informations pratiques
 
-**👉 Les informations pratiques, date, heure et lieu sont disponibles sur l'**[**agenda public**](https://calendar.google.com/calendar/embed?src=0ieonqap1r5jeal5ugeuhoovlg%40group.calendar.google.com\&ctz=Europe%2FParis) **de beta.gouv.fr**
+**👉 Les informations pratiques, date, heure et lieu sont disponibles sur l'**[**agenda public**](http://messagerie.numerique.gouv.fr/appsuite/api/share/0366722a002da2b9366722802da84e5eb694970c9c989a65/1/2/Y2FsOi8vMC8yMjczNA) **de beta.gouv.fr**
 
 {% hint style="info" %}
 **Déroulé-type d'un Forum beta.gouv.fr**

--- a/decouvrir-beta.gouv.fr/la-communaute/sinformer-sur-la-vie-de-la-communaute.md
+++ b/decouvrir-beta.gouv.fr/la-communaute/sinformer-sur-la-vie-de-la-communaute.md
@@ -24,7 +24,7 @@ Tu peux consulter les anciennes infolettres sur l'[espace membre](https://espace
 Pour suivre facilement les événements qui réunissent la communauté beta.gouv.fr, tu peux t'inscrire à l'agenda public de beta.gouv.fr !
 
 {% hint style="info" %}
-[Voir l'**agenda public**](https://calendar.google.com/calendar/u/1?cid=MGllb25xYXAxcjVqZWFsNXVnZXVob292bGdAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ)
+[Voir l'**agenda public**](http://messagerie.numerique.gouv.fr/appsuite/api/share/0366722a002da2b9366722802da84e5eb694970c9c989a65/1/2/Y2FsOi8vMC8yMjczNA)
 {% endhint %}
 
 {% hint style="info" %}

--- a/gerer-son-produit/la-vie-du-produit/investigation/lespace-collaboratif-dincubation-produit-sur-figjam.md
+++ b/gerer-son-produit/la-vie-du-produit/investigation/lespace-collaboratif-dincubation-produit-sur-figjam.md
@@ -47,7 +47,7 @@ Dans l'esprit d'un commun, nous avons l'intention de faire évoluer cet espace n
 Vous avez une évolution ou un nouveau tableau à partager ? Une question, un cri du coeur, envie d’ajouter des ateliers ?&#x20;
 
 * Écrivez sur le channel mattermost #domaine-coaching de beta.gouv&#x20;
-* Participe à la communauté des coachs au Forum de Beta.gouv. ([agenda disponibles ici ](https://calendar.google.com/calendar/u/0/embed?src=0ieonqap1r5jeal5ugeuhoovlg@group.calendar.google.com\&ctz=Europe/Paris)🔗)
+* Participe à la communauté des coachs au Forum de Beta.gouv. ([agenda disponibles ici ](http://messagerie.numerique.gouv.fr/appsuite/api/share/0366722a002da2b9366722802da84e5eb694970c9c989a65/1/2/Y2FsOi8vMC8yMjczNA)🔗)
 
 L'enjeu est de garder un board simple et accessible. L'équipe animation sélectionnera les modifications à ajouter au board "master", des autres suggestions qui pourront être ajoutées une zone d'annexes avec les variantes.
 

--- a/les-outils-de-la-communaute/agenda-de-la-communaute.md
+++ b/les-outils-de-la-communaute/agenda-de-la-communaute.md
@@ -1,9 +1,9 @@
 # 📅 Agenda de la communauté
 
-Les évènements de la communauté beta.gouv.fr sont référencés sur un [agenda public](http://messagerie.numerique.gouv.fr/appsuite/api/share/0366722a002da2b9366722802da84e5eb694970c9c989a65/1/2/Y2FsOi8vMC8yMjczNA). Il est visible par tout le monde et peut être ajouté à un gestionnaire d'agenda via son adresse [iCal](https://calendar.google.com/calendar/ical/0ieonqap1r5jeal5ugeuhoovlg%40group.calendar.google.com/public/basic.ics) ou [email](mailto:0ieonqap1r5jeal5ugeuhoovlg@group.calendar.google.com).
+Les évènements de la communauté beta.gouv.fr sont référencés sur un [agenda public](http://messagerie.numerique.gouv.fr/appsuite/api/share/0366722a002da2b9366722802da84e5eb694970c9c989a65/1/2/Y2FsOi8vMC8yMjczNA). Il est visible par tout le monde et peut être ajouté à ton propre gestionnaire d'agenda.
 
 ![Image d'illustration](<../.gitbook/assets/image (18).png>)
 
 {% hint style="info" %}
-[Ajouter un évènement à l'agenda de beta](https://airtable.com/shrWvcUAOJqllVqtj)
+Pour ajouter un évènement à l'agenda de la communauté, contacte l'équipe animation sur Tchap.
 {% endhint %}

--- a/les-outils-de-la-communaute/agenda-de-la-communaute.md
+++ b/les-outils-de-la-communaute/agenda-de-la-communaute.md
@@ -1,6 +1,6 @@
 # 📅 Agenda de la communauté
 
-Les évènements de la communauté beta.gouv.fr sont référencés sur un [agenda public](https://calendar.google.com/calendar/embed?src=0ieonqap1r5jeal5ugeuhoovlg%40group.calendar.google.com\&ctz=Europe/Paris). Il est visible par tout le monde et peut être ajouté à un gestionnaire d'agenda via son adresse [iCal](https://calendar.google.com/calendar/ical/0ieonqap1r5jeal5ugeuhoovlg%40group.calendar.google.com/public/basic.ics) ou [email](mailto:0ieonqap1r5jeal5ugeuhoovlg@group.calendar.google.com).
+Les évènements de la communauté beta.gouv.fr sont référencés sur un [agenda public](http://messagerie.numerique.gouv.fr/appsuite/api/share/0366722a002da2b9366722802da84e5eb694970c9c989a65/1/2/Y2FsOi8vMC8yMjczNA). Il est visible par tout le monde et peut être ajouté à un gestionnaire d'agenda via son adresse [iCal](https://calendar.google.com/calendar/ical/0ieonqap1r5jeal5ugeuhoovlg%40group.calendar.google.com/public/basic.ics) ou [email](mailto:0ieonqap1r5jeal5ugeuhoovlg@group.calendar.google.com).
 
 ![Image d'illustration](<../.gitbook/assets/image (18).png>)
 

--- a/solliciter-et-contribuer-a-la-communaute/je-contribue-a-la-communaute-to-do/README.md
+++ b/solliciter-et-contribuer-a-la-communaute/je-contribue-a-la-communaute-to-do/README.md
@@ -10,7 +10,7 @@ description: >-
 
 La communauté se réunit régulièrement autour d'événements pour partager des expériences, s'entraider sur des problèmes du quotidien et passer du bon temps !
 
-Pour connaître les prochains événéments, tu peux rejoindre l'[agenda public de beta.gouv.fr](https://calendar.google.com/calendar/u/0/embed?src=0ieonqap1r5jeal5ugeuhoovlg@group.calendar.google.com\&ctz=Europe/Paris) : tu auras accès à toutes les informations concernant ces événements, ainsi que des rappels utiles pour ne manquer aucune occasion de partager avec les autres membres des incubateurs. 📅
+Pour connaître les prochains événéments, tu peux rejoindre l'[agenda public de beta.gouv.fr](http://messagerie.numerique.gouv.fr/appsuite/api/share/0366722a002da2b9366722802da84e5eb694970c9c989a65/1/2/Y2FsOi8vMC8yMjczNA) : tu auras accès à toutes les informations concernant ces événements, ainsi que des rappels utiles pour ne manquer aucune occasion de partager avec les autres membres des incubateurs. 📅
 
 Chaque membre de la communauté est également livre d'organiser un événement ouvert aux autres membres (séminaire dans une ville, rencontre, formation, etc.).
 

--- a/solliciter-et-contribuer-a-la-communaute/je-contribue-a-la-communaute-to-do/partager-ses-apprentissages/mardi-demo.md
+++ b/solliciter-et-contribuer-a-la-communaute/je-contribue-a-la-communaute-to-do/partager-ses-apprentissages/mardi-demo.md
@@ -13,5 +13,5 @@ Nous encourageons chaque équipe à proposer une **démonstration** de son produ
 
 ### Organisation
 
-* caler un créneau dans l'[agenda public de l'incubateur](https://calendar.google.com/calendar/u/0/embed?src=0ieonqap1r5jeal5ugeuhoovlg@group.calendar.google.com\&ctz=Europe/Paris) avec un lien de visio ou une localisation physique lorsque c'est possible ;
+* caler un créneau dans l'[agenda public de l'incubateur](http://messagerie.numerique.gouv.fr/appsuite/api/share/0366722a002da2b9366722802da84e5eb694970c9c989a65/1/2/Y2FsOi8vMC8yMjczNA) avec un lien de visio ou une localisation physique lorsque c'est possible ;
 * communiquer pour informer les personnes susceptibles d'être intéressées : via Mattermost ou via l'infolettre hebdomadaire de beta.gouv.fr.

--- a/travailler-chez-beta.gouv.fr/les-differents-metiers/intrapreneur/README.md
+++ b/travailler-chez-beta.gouv.fr/les-differents-metiers/intrapreneur/README.md
@@ -49,7 +49,7 @@ Pour échanger entre intras, il existe un canal privé : [\~domaine-intras-priv�
 
 ### Le club intras
 
-Un club intras a lieu a chaque forum mensuel de la communauté beta.gouv.fr. Pour connaitre la date, il suffit de consulter l'[agenda ](https://calendar.google.com/calendar/embed?src=0ieonqap1r5jeal5ugeuhoovlg%40group.calendar.google.com\&ctz=Europe/Paris)public de la communauté.
+Un club intras a lieu a chaque forum mensuel de la communauté beta.gouv.fr. Pour connaitre la date, il suffit de consulter l'[agenda ](http://messagerie.numerique.gouv.fr/appsuite/api/share/0366722a002da2b9366722802da84e5eb694970c9c989a65/1/2/Y2FsOi8vMC8yMjczNA)public de la communauté.
 
 Vous serez également prévenu via Mattermost et directement invité à l'occurrence agenda.
 

--- a/travailler-chez-beta.gouv.fr/se-former/animer-une-formation.md
+++ b/travailler-chez-beta.gouv.fr/se-former/animer-une-formation.md
@@ -23,7 +23,7 @@ Si tu souhaites proposer une formation, c'est par ici : "[Je propose une formati
 
 ### Comment choisir la date et l'horaire
 
-Selon le public visé, il est conseillé de vérifer d'abord sur [l'agenda public](https://calendar.google.com/calendar/embed?src=0ieonqap1r5jeal5ugeuhoovlg%40group.calendar.google.com\&ctz=Europe%2FParis) qu'aucun évènement Beta ne se chevauche avec votre proposition de date. Vous pouvez ensuite vérifier avec d'autres incubateurs très présents dans la communauté Beta qu'ils n'organisent pas d'évènement en même temps que le vôtre, si vous estimez qu'il y a un fort risque de conflit entre les deux.
+Selon le public visé, il est conseillé de vérifer d'abord sur [l'agenda public](http://messagerie.numerique.gouv.fr/appsuite/api/share/0366722a002da2b9366722802da84e5eb694970c9c989a65/1/2/Y2FsOi8vMC8yMjczNA) qu'aucun évènement Beta ne se chevauche avec votre proposition de date. Vous pouvez ensuite vérifier avec d'autres incubateurs très présents dans la communauté Beta qu'ils n'organisent pas d'évènement en même temps que le vôtre, si vous estimez qu'il y a un fort risque de conflit entre les deux.
 
 Les créneaux pendant lesquels les personnes sont le plus souvent disponibles sont _10h-12h_, et _14h-16h30_. Un horaire plus tardif est plus difficile à gérer pour les jeunes parents, par exemple.
 

--- a/travailler-chez-beta.gouv.fr/to-do-darrivee/README.md
+++ b/travailler-chez-beta.gouv.fr/to-do-darrivee/README.md
@@ -58,7 +58,7 @@ Tu peux la consulter en version documentation juste ici 👇.
 * [ ] Découvrir [les canaux mattermost recommandés](../../les-outils-de-la-communaute/mattermost/canaux-recommandes.md)
 * [ ] Publier un message pour signaler ton arrivée aux membres de la communauté beta.gouv près de chez toi via ton [canal mattermost local](https://doc.incubateur.net/communaute/les-outils-de-la-communaute/mattermost/canaux-recommandes). Si aucun ne correspond, tu peux regarder si d'autres membres de la communauté sont près de chez toi sur la [carte des membres](https://espace-membre.incubateur.net/community)
 * [ ] Découvrir [tous les lieux où travailler ou organiser des événements](../vie-quotidienne-et-bien-etre/travailler-dans-les-lieux-partages/)
-* [ ] T'abonner à [l'agenda public de l'incubateur](https://calendar.google.com/calendar/u/0/r?cid=MGllb25xYXAxcjVqZWFsNXVnZXVob292bGdAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ) pour suivre les événements de la communauté
+* [ ] T'abonner à [l'agenda public de l'incubateur](http://messagerie.numerique.gouv.fr/appsuite/api/share/0366722a002da2b9366722802da84e5eb694970c9c989a65/1/2/Y2FsOi8vMC8yMjczNA) pour suivre les événements de la communauté
 
 **Appréhender ton environnement**
 


### PR DESCRIPTION
Migration de l'agenda public de Google Calendar vers LaSuite : mise à jour du lien de consultation dans 11 fichiers de la doc.